### PR TITLE
Force use static libgomp when -static-libgcc is specified

### DIFF
--- a/image/build.sh
+++ b/image/build.sh
@@ -412,4 +412,6 @@ if ! eval_bool "$SKIP_FINALIZE"; then
 	for VARIANT in $VARIANTS; do
 		run rm -rf "/hbb_$VARIANT/share/doc" "/hbb_$VARIANT/share/man"
 	done
+
+	echo "*link_gomp: %{static|static-libgcc|static-libstdc++|static-libgfortran: libgomp.a%s; : -lgomp } %{static: -ldl }" > /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libgomp.spec
 fi


### PR DESCRIPTION
gcc from devtoolset does not link libgomp statically even with `-static-libgcc` option is specified. This rewrites gcc spec file to select the static / shared library depending on the set of options (otherwise `libcheck` certainly complains about unknown system library `libgomp.so`).