### PR TITLE
Force use static libgomp when -static-libgcc is specified

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 ## Version 3.0.4 (unreleased)
 
+ * Fixes C++ compiler problems. Upgrades libstdc++ to 9.3.0 in order to match the GCC version. Fix contributed by @asl, closes #47.
+ * Fixes static linking to libgomp when -static-libgcc is used. Fix contributed by @asl, closes #50.
  * Upgrades tools and libraries:
 
     - CMake 3.19.3 -> 3.22.2

--- a/image/build.sh
+++ b/image/build.sh
@@ -67,6 +67,8 @@ if ! eval_bool "$SKIP_INITIALIZE"; then
 		file patch bzip2 zlib-devel gettext python-setuptools python-devel \
 		epel-release centos-release-scl
 	run yum install -y python2-pip "devtoolset-$DEVTOOLSET_VERSION"
+
+	echo "*link_gomp: %{static|static-libgcc|static-libstdc++|static-libgfortran: libgomp.a%s; : -lgomp } %{static: -ldl }" > /opt/rh/devtoolset-9/root/usr/lib/gcc/x86_64-redhat-linux/9/libgomp.spec
 fi
 
 


### PR DESCRIPTION
> Originally contributed by @asl in #50.

gcc from devtoolset does not link libgomp statically even with -static-libgcc option is specified. This rewrites gcc spec file to select the static / shared library depending on the set of options (otherwise `libcheck` certainly complains about unknown system library `libgomp.so`).